### PR TITLE
Fix boolean conversion error in departments.js

### DIFF
--- a/lib/route/departments.js
+++ b/lib/route/departments.js
@@ -43,12 +43,9 @@ function get_and_validate_department(args) {
   const manager_id =
     getParam('manager_id') && validator.trim(getParam('manager_id'))
 
-  const include_public_holidays = validator.toBoolean(
-    getParam('include_public_holidays') === 'on'
-  )
-  const is_accrued_allowance = validator.toBoolean(
-    getParam('is_accrued_allowance') === 'on'
-  )
+  const include_public_holidays = getParam('include_public_holidays') === 'on'
+  const is_accrued_allowance = getParam('is_accrued_allowance') === 'on'
+
 
   // Validate provided parameters
   //


### PR DESCRIPTION
### Summary
This fixes a TypeError occurring when adding a department:

```
TypeError: Expected a string but received a Boolean
```

The issue was in `departments.js` where `validator.toBoolean()` was called
on a boolean expression. The `validator` library expects a string input, so
passing a boolean caused the error.

### Changes
Replaced the previous code:

```js
const include_public_holidays = validator.toBoolean(
    getParam('include_public_holidays') === 'on'
)
const is_accrued_allowance = validator.toBoolean(
    getParam('is_accrued_allowance') === 'on'
)
```

With the corrected code:

```js
const include_public_holidays = getParam('include_public_holidays') === 'on'
const is_accrued_allowance = getParam('is_accrued_allowance') === 'on'
```

This preserves the intended boolean logic while avoiding the TypeError.

### Notes
- This change does not alter functionality; it only ensures type safety.
- Tested locally, adding a department now works without errors.
